### PR TITLE
tu/kgsl: Fix patched Turnip for Adreno 830/840

### DIFF
--- a/src/freedreno/vulkan/tu_knl_kgsl.cc
+++ b/src/freedreno/vulkan/tu_knl_kgsl.cc
@@ -1754,10 +1754,7 @@ tu_kgsl_get_raytracing(int fd)
 VkResult
 tu_knl_kgsl_load(struct tu_instance *instance, int fd)
 {
-   if (instance->vk.enabled_extensions.KHR_display) {
-      return vk_errorf(instance, VK_ERROR_INITIALIZATION_FAILED,
-                       "I can't KHR_display");
-   }
+
 
    struct tu_physical_device *device = (struct tu_physical_device *)
       vk_zalloc(&instance->vk.alloc, sizeof(*device), 8,

--- a/src/freedreno/vulkan/tu_knl_kgsl.cc
+++ b/src/freedreno/vulkan/tu_knl_kgsl.cc
@@ -91,6 +91,7 @@ bo_init_new_dmaheap(struct tu_device *dev, struct tu_bo **out_bo, uint64_t size,
                     &alloc);
 
    if (ret) {
+      mesa_logd("tu_knl_kgsl: DMA_HEAP_IOCTL_ALLOC failed, errno: %d (%s)", errno, strerror(errno));
       return vk_errorf(dev, VK_ERROR_OUT_OF_DEVICE_MEMORY,
                        "DMA_HEAP_IOCTL_ALLOC failed (%s)", strerror(errno));
    }
@@ -112,6 +113,7 @@ bo_init_new_ion(struct tu_device *dev, struct tu_bo **out_bo, uint64_t size,
    int ret;
    ret = safe_ioctl(dev->physical_device->kgsl_dma_fd, ION_IOC_NEW_ALLOC, &alloc);
    if (ret) {
+      mesa_logd("tu_knl_kgsl: ION_IOC_NEW_ALLOC failed, errno: %d (%s)", errno, strerror(errno));
       return vk_errorf(dev, VK_ERROR_OUT_OF_DEVICE_MEMORY,
                        "ION_IOC_NEW_ALLOC failed (%s)", strerror(errno));
    }
@@ -134,6 +136,7 @@ bo_init_new_ion_legacy(struct tu_device *dev, struct tu_bo **out_bo, uint64_t si
    int ret;
    ret = safe_ioctl(dev->physical_device->kgsl_dma_fd, ION_IOC_ALLOC, &alloc);
    if (ret) {
+      mesa_logd("tu_knl_kgsl: ION_IOC_ALLOC failed, errno: %d (%s)", errno, strerror(errno));
       return vk_errorf(dev, VK_ERROR_OUT_OF_DEVICE_MEMORY,
                        "ION_IOC_ALLOC failed (%s)", strerror(errno));
    }
@@ -1771,15 +1774,19 @@ tu_knl_kgsl_load(struct tu_instance *instance, int fd)
    dma_fd = open(dma_heap_path, O_RDONLY);
    if (dma_fd >= 0) {
       device->kgsl_dma_type = TU_KGSL_DMA_TYPE_DMAHEAP;
+      mesa_logi("KGSL: Using DMAHEAP (/dev/dma_heap/system)");
    } else {
       dma_fd = open(ion_path, O_RDONLY);
       if (dma_fd >= 0) {
          /* ION_IOC_FREE available only for legacy ION */
          struct ion_handle_data free = { .handle = 0 };
-         if (safe_ioctl(dma_fd, ION_IOC_FREE, &free) >= 0 || errno != ENOTTY)
+         if (safe_ioctl(dma_fd, ION_IOC_FREE, &free) >= 0 || errno != ENOTTY) {
             device->kgsl_dma_type = TU_KGSL_DMA_TYPE_ION_LEGACY;
-         else
+            mesa_logi("KGSL: Using ION_LEGACY (/dev/ion)");
+         } else {
             device->kgsl_dma_type = TU_KGSL_DMA_TYPE_ION;
+            mesa_logi("KGSL: Using ION (/dev/ion)");
+         }
       } else {
          mesa_logw(
             "Unable to open neither %s nor %s, VK_KHR_external_memory_fd would be "
@@ -1793,6 +1800,8 @@ tu_knl_kgsl_load(struct tu_instance *instance, int fd)
    struct kgsl_devinfo info;
    if (get_kgsl_prop(fd, KGSL_PROP_DEVICE_INFO, &info, sizeof(info)))
       goto fail;
+
+   mesa_logi("KGSL: chip_id: 0x%08" PRIx32, info.chip_id);
 
    uint64_t gmem_iova;
    if (get_kgsl_prop(fd, KGSL_PROP_UCHE_GMEM_VADDR, &gmem_iova, sizeof(gmem_iova)))

--- a/src/vulkan/wsi/wsi_common.c
+++ b/src/vulkan/wsi/wsi_common.c
@@ -2777,8 +2777,10 @@ wsi_create_buffer_blit_context(const struct wsi_swapchain *chain,
 
    result = wsi->AllocateMemory(chain->device, &buf_mem_info,
                                 &chain->alloc, &image->blit.memory);
-   if (result != VK_SUCCESS)
+   if (result != VK_SUCCESS) {
+      mesa_logd("wsi: AllocateMemory (blit) failed with %d", result);
       return result;
+   }
 
    result = wsi->BindBufferMemory(chain->device, image->blit.buffer,
                                   image->blit.memory, 0);


### PR DESCRIPTION
Currently, the Turnip driver from the standard release (whose release title doesn't have the turnip- prefix) fails to work on most Adreno GPUs, and the possible error messages are as follows. This PR aims to fix this issue.

```
[Vulkan Loader] WARNING | LAYER: env var 'VK_INSTANCE_LAYERS' defined and adding layers "VK_LAYER_KHRONOS_validation"
[Vulkan Loader] ERROR | LAYER:  Layer "VK_LAYER_KHRONOS_validation" was not found but was requested by env var VK_INSTANCE_LAYERS!
[Vulkan Loader] WARNING | LAYER: env var 'VK_INSTANCE_LAYERS' defined and adding layers "VK_LAYER_KHRONOS_validation"
[Vulkan Loader] ERROR | LAYER:  Layer "VK_LAYER_KHRONOS_validation" was not found but was requested by env var VK_INSTANCE_LAYERS!
[Vulkan Loader] LAYER:          vkCreateInstance layer callstack setup to:
[Vulkan Loader] LAYER:             <Application>
[Vulkan Loader] LAYER:               ||
[Vulkan Loader] LAYER:             <Loader>
[Vulkan Loader] LAYER:               ||
[Vulkan Loader] LAYER:             <Drivers>
TU: info: TU_DEBUG=0x20003
TU: info: Created an instance
[Vulkan Loader] ERROR:          setup_loader_term_phys_devs: Call to 'vkEnumeratePhysicalDevices' in ICD /usr/lib/aarch64-linux-gnu/libvulkan_freedreno.so failed with error code -3
[Vulkan Loader] ERROR:          setup_loader_term_phys_devs:  Failed to detect any valid GPUs in the current config
vkcube: ./cube/cube.c:4153: demo_select_physical_device: Assertion `!err' failed.
```