### PR TITLE
freedreno/common: add unofficial support for Adreno 722

### DIFF
--- a/src/freedreno/common/freedreno_devices.py
+++ b/src/freedreno/common/freedreno_devices.py
@@ -1035,6 +1035,26 @@ add_gpus([
     ))
 
 add_gpus([
+        GPUId(chip_id=0x43020100, name="FD722"),
+        GPUId(chip_id=0xffff43020100, name="FD722"),
+    ], A6xxGPUInfo(
+        CHIP.A7XX,
+        [a7xx_base, a7xx_gen1],
+        num_ccu = 3,
+        tile_align_w = 64,
+        tile_align_h = 32,
+        tile_max_w = 1024,
+        tile_max_h = 1024,
+        num_vsc_pipes = 32,
+        cs_shared_mem_size = 32 * 1024,
+        wave_granularity = 2,
+        fibers_per_sp = 128 * 2 * 16,
+        highest_bank_bit = 16,
+        magic_regs = a730_magic_regs,
+        raw_magic_regs = a730_raw_magic_regs,
+    ))
+
+add_gpus([
         GPUId(chip_id=0xffff43030c00, name="Adreno X1-45"),
         GPUId(chip_id=0x43030B00, name="FD735")
     ], A6xxGPUInfo(


### PR DESCRIPTION
Adreno 722's device definition is from **Vauzi-17**: https://github.com/Vauzi-17/710/commit/df5319f68ee857c598fffd18012d066c91ed5c08