### PR TITLE
[NOT FOR MERGE] freedreno/kgsl: try dma-buf export before shadowing

### DIFF
--- a/src/gallium/drivers/freedreno/freedreno_resource.c
+++ b/src/gallium/drivers/freedreno/freedreno_resource.c
@@ -1115,22 +1115,8 @@ fd_resource_get_handle(struct pipe_screen *pscreen, struct pipe_context *pctx,
 
    handle->modifier = fd_resource_modifier(rsc);
 
-   if (fd_screen(pscreen)->kgsl_dmabuf) {
+   if (fd_screen(pscreen)->kgsl_dmabuf)
       handle->modifier = DRM_FORMAT_MOD_LINEAR;
-
-      if (!(prsc->bind & PIPE_BIND_SHARED)) {
-         struct fd_context *ctx = fd_screen_aux_context_get(pscreen);
-
-         prsc->bind |= PIPE_BIND_SHARED;
-
-         bool ret = fd_try_shadow_resource(ctx, rsc, 0, NULL, handle->modifier);
-
-         fd_screen_aux_context_put(pscreen);
-
-         if (!ret)
-            return false;
-      }
-   }
 
    if (prsc->target != PIPE_BUFFER) {
       struct fdl_metadata metadata = {


### PR DESCRIPTION
> [!NOTE]
> **This PR will not be merged**, because although it resolves the issue of running "Weston (Anland) + XWayland + Vulkan" **under Termux native** and has almost no impact on the performance of KWin (Anland) under Termux native, it will cause the performance of KWin (Anland) accelerated by Freedreno & Turnip drivers inside **PRoot/Chroot containers** to drop significantly on certain GPU models (such as Adreno 730).
> 
> If you need to resolve the issue of running "Weston (Anland) + XWayland + Vulkan" under Termux native, you can find the corresponding build artifacts here: https://github.com/lfdevs/termux-packages/actions/runs/29795986556?pr=17#artifacts or https://github.com/lfdevs/termux-packages/releases/tag/freedreno-26.2.0-devel-20260709-weston

Currently, using [Anland: Termux](https://github.com/lfdevs/anland-termux) and drivers built by this project in Termux native, and under a Weston session, running applications with the XWayland + Vulkan combination will crash. The key logs are as follows. This PR aims to resolve this issue.

```log
linux-dmabuf: created wl_buffer from KGSL dmabuf
../src/src/gallium/drivers/freedreno/a6xx/fd6_texture.cc:854: struct fd6_texture_state *fd6_texture_state(struct fd_context *, mesa_shader_stage) [CHIP = A8XX]: assertion "state->view_rsc_seqno[i] == seqno" failed
```

The Weston Termux package with the added Anland 5.13 backend comes from: https://github.com/lfdevs/termux-packages/pull/14

---

Imported KGSL BOs can already carry a valid dma-buf fd even when the pipe resource was not created with PIPE_BIND_SHARED. Shadowing such resources before attempting export unnecessarily replaces their backing storage and can leave cached texture state referring to the old resource sequence number.

Keep the LINEAR modifier requirement, but try the normal export path first. Native KGSL BOs that cannot be exported still fall back to a shared linear shadow resource. This avoids Xwayland aborts when presenting imported Vulkan DRI3 buffers.