### PR TITLE
freedreno/common: add unofficial support for Adreno 732

### DIFF
--- a/src/freedreno/common/freedreno_devices.py
+++ b/src/freedreno/common/freedreno_devices.py
@@ -1091,7 +1091,10 @@ add_gpus([
 
 add_gpus([
         GPUId(chip_id=0xffff43030c00, name="Adreno X1-45"),
-        GPUId(chip_id=0x43030B00, name="FD735")
+        GPUId(chip_id=0x43030B00, name="FD735"),
+        GPUId(chip_id=0xffff43030b00, name="FD735"), # any-speedbin fallback (covers a732 = binned a735 theory)
+        GPUId(chip_id=0x43030a00, name="FD735"),     # speculative a732 own id
+        GPUId(chip_id=0xffff43030a00, name="FD735")  # speculative a732 any-speedbin
     ], A6xxGPUInfo(
         CHIP.A7XX,
         [a7xx_base, a7xx_gen2, GPUProps(enable_tp_ubwc_flag_hint = True)],


### PR DESCRIPTION
This patch is from SansNope's repo: https://github.com/SansNope/UnleashedRecomp-Android/blob/57bbe855e4abcb9849df4543d7350829fc86ca0e/turnip-driver-ci/patches-unleashed/0004-a732-bringup-ids.patch